### PR TITLE
Use bats for bash testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@types/node": "^12.20.27",
         "@typescript-eslint/eslint-plugin": "^4.32.0",
         "@typescript-eslint/parser": "^4.32.0",
+        "bats": "^1.4.1",
+        "bats-assert": "^2.0",
         "eslint": "7.32.0",
         "prettier": "2.4.1",
         "typescript": "4.4.3"
@@ -442,6 +444,30 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bats": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.4.1.tgz",
+      "integrity": "sha512-sZgqfOHgPqtQSD84WKQiNU3a/44hQiiHGtA43gTUPeOdl5jYhnXSBNGCa8DGlKc8JpI/UUYcaPNf0Afg3OOibQ==",
+      "dev": true,
+      "bin": {
+        "bats": "bin/bats"
+      }
+    },
+    "node_modules/bats-assert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bats-assert/-/bats-assert-2.0.0.tgz",
+      "integrity": "sha512-qO3kNilWxW8iCONu9NDUfvsCiC6JzL6DPOc/DGq9z3bZ9/A7wURJ+FnFMxGbofOmWbCoy7pVhofn0o47A95qkQ==",
+      "dev": true,
+      "peerDependencies": {
+        "bats-support": "git+https://github.com/ztombol/bats-support.git#v0.2.0"
+      }
+    },
+    "node_modules/bats-support": {
+      "version": "0.2.0",
+      "resolved": "git+ssh://git@github.com/ztombol/bats-support.git#d0a131831c487a1f1141e76d3ab386c89642cdff",
+      "dev": true,
+      "peer": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2077,6 +2103,25 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "bats": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.4.1.tgz",
+      "integrity": "sha512-sZgqfOHgPqtQSD84WKQiNU3a/44hQiiHGtA43gTUPeOdl5jYhnXSBNGCa8DGlKc8JpI/UUYcaPNf0Afg3OOibQ==",
+      "dev": true
+    },
+    "bats-assert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bats-assert/-/bats-assert-2.0.0.tgz",
+      "integrity": "sha512-qO3kNilWxW8iCONu9NDUfvsCiC6JzL6DPOc/DGq9z3bZ9/A7wURJ+FnFMxGbofOmWbCoy7pVhofn0o47A95qkQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "bats-support": {
+      "version": "git+ssh://git@github.com/ztombol/bats-support.git#d0a131831c487a1f1141e76d3ab386c89642cdff",
+      "dev": true,
+      "from": "bats-support@git+https://github.com/ztombol/bats-support.git#v0.2.0",
+      "peer": true
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@types/node": "^12.20.27",
     "@typescript-eslint/eslint-plugin": "^4.32.0",
     "@typescript-eslint/parser": "^4.32.0",
+    "bats": "^1.4.1",
+    "bats-assert": "^2.0",
     "eslint": "7.32.0",
     "prettier": "2.4.1",
     "typescript": "4.4.3"

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,44 +1,35 @@
-#!/bin/bash
+#!/usr/bin/env bats
 
-die() {
-  echo "$*" 1>&2
-  exit 1
+load '../node_modules/bats-assert/load'
+
+@test "Expressions CLI" {
+  run node dist/expressions/cli.js --pretty <test/expressions-input.json
+  assert_output <test/expressions.expected.json
 }
 
-# set -x # print each line as it's executed
-set -e # exit at the first error
+@test 'Templates CLI' {
+  run node dist/templates/cli.js --pretty <test/templates-input.json
+  assert_output <test/templates.expected.json
+}
 
-mkdir -p _temp
+@test "Templates CLI with unknown flag" {
+  run node dist/templates/cli.js --wat
+  assert_output --partial  "Error: Unknown option 'wat'"
+  assert_failure
+}
 
-echo 'Testing CLI'
-set +e
-# unknown flags should print usage and return error
-node dist/templates/cli.js --wat >_temp/cli-unknown-option.actual.json 2>&1
-[[ "$?" == 1 ]] || die "unexpected return status '$?'"
-grep -q "Error: Unknown option 'wat'" _temp/cli-unknown-option.actual.json
+@test "Templates CLI with --help" {
+  run node dist/templates/cli.js --help
+  assert_output --partial  "Usage:"
+  assert_failure # this should really exit 0
+}
 
-# `--help` should print usage
-node dist/templates/cli.js --help >_temp/cli-help.actual.json 2>&1
-grep -q "Usage:" _temp/cli-help.actual.json
-echo 'Success'
-set -e
+@test 'Templates CLI with --no-expand-expressions' {
+  run node dist/templates/cli.js --pretty --no-expand-expressions <test/templates-input.json
+  assert_output <test/templates.expected.json
+}
 
-echo 'Testing expressions'
-node dist/expressions/cli.js --pretty >_temp/expressions.actual.json 2>&1 <test/expressions-input.json
-diff test/expressions.expected.json _temp/expressions.actual.json
-echo 'Success'
-
-echo 'Testing template reader with --expand-expressions'
-node dist/templates/cli.js --pretty >_temp/templates.actual.json 2>&1 <test/templates-input.json
-diff test/templates.expected.json _temp/templates.actual.json
-echo 'Success'
-
-echo 'Testing template reader with --no-expand-expressions'
-node dist/templates/cli.js --pretty --no-expand-expressions >_temp/templates-no-expand.actual.json 2>&1 <test/templates-input.json
-diff test/templates.expected.json _temp/templates-no-expand.actual.json
-echo 'Success'
-
-echo 'Testing workflow parser'
-node dist/workflows/cli.js --pretty >_temp/workflow-parser.actual.json 2>&1 <test/workflow-parser-input.json
-diff test/workflow-parser.expected.json _temp/workflow-parser.actual.json
-echo 'Success'
+@test 'Workflows CLI' {
+  run node dist/workflows/cli.js --pretty <test/workflow-parser-input.json
+  assert_output <test/workflow-parser.expected.json
+}


### PR DESCRIPTION
This gives us a lot of built-in stuff that we'd have to roll by hand when doing our own bash testing. 

It simplifies the test files themselves and gives us prettier output. 

```
❍ npm run test

> actions-yaml@0.1.0 test
> ./test/test.sh

 ✓ Expressions CLI
 ✓ Templates CLI
 ✓ Templates CLI with unknown flag
 ✓ Templates CLI with --help
 ✓ Templates CLI with --no-expand-expressions
 ✓ Workflows CLI

6 tests, 0 failures
```

WDYT?